### PR TITLE
添加删除一个key下所有id对应的数据的功能

### DIFF
--- a/__tests__/basic-function-promise-test.js
+++ b/__tests__/basic-function-promise-test.js
@@ -133,4 +133,55 @@ describe('react-native-storage: basic function(promise)', () => {
       expect(ret2[1]).toBe('catched');
     });
   });
+  pit('remove Key-Id data correctly', () =>{
+    let testKey = 'testKey' + Math.random(),
+      testId = 'testId' + Math.random(),
+      testData = 'testData' + Math.random();
+    let ret = [undefined, undefined];
+    let task = (key, id, rawData, retArray) => {
+      return storage.save({
+        key,
+        id,
+        rawData
+      }).then(() => {
+        return storage.load({
+          key,
+          id
+        });
+      }).then( ret => {
+        retArray[0] = ret;
+        storage.clearMapForKey(key);
+      }).then( () => {
+        return storage.load({ key, id });
+      }).then( ret => {
+        retArray[1] = ret;
+      }).catch( () => {
+        retArray[1] = 'catched';
+      });;
+    };
+    return Promise.all([
+      task(testKey, testId, testData, ret)
+    ]).then(() => {
+      expect(ret[0]).toBe(testData);
+      expect(ret[1]).toBe('catched');
+    });
+  })
+
+
+  pit('load ids by key correctly', () => {
+    let key = 'testKey' + Math.random(),
+      testIds = [Math.random(), Math.random(), Math.random()],
+      rawData = 'testData' + Math.random();
+    let ret = [];
+    let tasks = testIds.map(function(id){
+      return storage.save({
+          key,
+          id,
+          rawData
+        });
+    });
+    return Promise.all(tasks).then(() => {
+      expect(storage.getIdsForKey(key)).toEqual(testIds)
+    })
+  });
 });

--- a/storage.js
+++ b/storage.js
@@ -18,7 +18,7 @@ export default class Storage {
     me.cache = {};
 
     if(!me._s) {
-      if(window && window.localStorage) {
+      if(typeof window !== 'undefined' && window.localStorage) {
         try {
           // avoid key conflict
           window.localStorage.setItem('__react_native_storage_test', 'test');
@@ -90,8 +90,9 @@ export default class Storage {
     if(m[m.index] !== undefined){
       //loop over, delete old data
       let oldId = m[m.index];
+      let splitOldId = oldId.split('_')
       delete m[oldId];
-      this._removeIdInKey(oldId.split('_')[1])
+      this._removeIdInKey(splitOldId[0], splitOldId[1])
       if(this.enableCache) {
         delete this.cache[oldId];
       }
@@ -326,6 +327,17 @@ export default class Storage {
       me.remove({ key: key, id: id });
     });
   }
+  getIdsForKey(key) {
+    return this._m.__keys__[key] || []
+  }
+  getAllDataForKey(key, options) {
+    options = Object.assign({ syncInBackground: true }, options)
+    let querys = this.getIdsForKey(key).map(function(id){
+      return {key: key, id: id, syncInBackground: options.syncInBackground}
+    })
+    return this.getBatchData(querys)
+  }
+
 }
 
 // function noop() {}

--- a/storage.js
+++ b/storage.js
@@ -91,6 +91,7 @@ export default class Storage {
       //loop over, delete old data
       let oldId = m[m.index];
       delete m[oldId];
+      this._removeIdInKey(oldId.split('_')[1])
       if(this.enableCache) {
         delete this.cache[oldId];
       }
@@ -280,12 +281,19 @@ export default class Storage {
         if(me.enableCache && me.cache[newId]) {
           delete me.cache[newId];
         }
+        me._removeIdInKey(key, id)
         let idTobeDeleted = m[newId];
         delete m[newId];
         me.setItem('map', JSON.stringify(m));
         return me.removeItem('map_' + idTobeDeleted);
       }
     });
+  }
+  _removeIdInKey(key, id) {
+    let indexTobeRemoved = this._m.__keys__[key].indexOf(id)
+    if(indexTobeRemoved !== -1) {
+      this._m.__keys__[key].splice(indexTobeRemoved, 1)
+    }
   }
   load(params) {
     let me = this;
@@ -311,14 +319,12 @@ export default class Storage {
       index: 0
     };
   }
-
   clearMapForKey(key) {
     let me = this;
     let m = me._m;
     m.__keys__[key].forEach(function(id){
       me.remove({ key: key, id: id });
     });
-    m.__keys__[key] = []
   }
 }
 

--- a/storage.js
+++ b/storage.js
@@ -14,11 +14,11 @@ export default class Storage {
     me.enableCache = options.enableCache || true;
     me._s = options.storageBackend || null;
     me.isPromise = options.isPromise || true;
-    me._innerVersion = 10;
+    me._innerVersion = 11;
     me.cache = {};
 
     if(!me._s) {
-      if(typeof window !== 'undefined' && window.localStorage) {
+      if(window && window.localStorage) {
         try {
           // avoid key conflict
           window.localStorage.setItem('__react_native_storage_test', 'test');
@@ -70,7 +70,8 @@ export default class Storage {
     else {
       return {
         innerVersion: me._innerVersion,
-        index: 0
+        index: 0,
+        __keys__: {}
       };
     }
   }
@@ -96,6 +97,10 @@ export default class Storage {
     }
     m[newId] = m.index;
     m[m.index] = newId;
+
+    m.__keys__[key] = m.__keys__[key] || [];
+    m.__keys__[key].push(id);
+
     if(this.enableCache) {
       const cacheData = JSON.parse(data);
       this.cache[newId] = cacheData;
@@ -305,6 +310,15 @@ export default class Storage {
       innerVersion: me._innerVersion,
       index: 0
     };
+  }
+
+  clearMapForKey(key) {
+    let me = this;
+    let m = me._m;
+    m.__keys__[key].forEach(function(id){
+      me.remove({ key: key, id: id });
+    });
+    m.__keys__[key] = []
   }
 }
 


### PR DESCRIPTION
使用时希望能够单独删除某一个key下的所有id对应的数据，而不是通过clearMap一次性删除所有的Key-Id数据。所以在`_saveToMap`中，把Key和id在map里单独保存了一下。