### PR TITLE
 improve: NotFoundError and ExpireError should be subclasses of Error

### DIFF
--- a/__tests__/custom-error-test.js
+++ b/__tests__/custom-error-test.js
@@ -1,0 +1,20 @@
+jest.dontMock('../error.js');
+jest.dontMock('../storage.js');
+
+import { NotFoundError, ExpiredError } from '../error';
+
+describe('react-native-storage: custom error types', () => {
+    test('NotFoundError instance should be error instance', () => {
+        const error = new NotFoundError('somekey');
+        expect(error instanceof Error).toBe(true);
+        expect(error.toString().includes('somekey')).toBe(true);
+        expect(error.toString().includes('NotFoundError')).toBe(true);
+    });
+
+    test('ExpiredError instance should be error instance', () => {
+        const error = new ExpiredError('somekey');
+        expect(error instanceof Error).toBe(true);
+        expect(error.toString().includes('somekey')).toBe(true);
+        expect(error.toString().includes('ExpiredError')).toBe(true);
+    });
+});

--- a/error.js
+++ b/error.js
@@ -2,19 +2,19 @@
  * Created by sunny on 9/1/16.
  */
 
-export class NotFoundError {
+export class NotFoundError extends Error {
   constructor(message) {
+    super(`Not Found! Params: ${message}`);
     this.name = 'NotFoundError';
-    this.message = `Not Found! Params: ${message}`;
     this.stack = new Error().stack; // Optional
   }
 }
 // NotFoundError.prototype = Object.create(Error.prototype);
 
-export class ExpiredError {
+export class ExpiredError extends Error {
   constructor(message) {
+    super(`Expired! Params: ${message}`);
     this.name = 'ExpiredError';
-    this.message = `Expired! Params: ${message}`;
     this.stack = new Error().stack; // Optional
   }
 }


### PR DESCRIPTION
thanks for this useful library!

this is an improvement for custom error classes used in react-native-storage, and also fixes for the issue I encountered with current version:

the issue can be reproduced with the following code:

```javascript
const isShowSwiper = () => {
  return new Promise(resolve => {
    storage
      .load({ key: 'swiper.status' })
      .then(status => {
        resolve(!!status);
      })
      .catch(err => {
        console.warn(`UserStore.read.isShowSwiper.error: ${err}`);
        resolve(true);
      });
  });
};
```

the error message logged contains nothing meaningful but `[object Object]`, as developers meaningful error messages are very important.
